### PR TITLE
Disable building debug packages

### DIFF
--- a/vale.spec
+++ b/vale.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:          vale
 Version:       3.9.1
 Release:       1%{?dist}


### PR DESCRIPTION
This ensures that the RPM can be built on Fedora 41 and newer.