### PR TITLE
Disable debuginfo package generation

### DIFF
--- a/vale.spec
+++ b/vale.spec
@@ -17,6 +17,9 @@ markup-formatted files, such as Markdown,
 AsciiDoc, reStructuredText, HTML, or XML,
 and impose preferred spelling or a style guide.
 
+# Disable generation of debuginfo package
+%global debug_package %{nil}
+
 %prep
 %setup -qc
 


### PR DESCRIPTION
This should fix the build issue on F41 and above.

We don't need a debuginfo package as we don't build from source (which is bad, but we can address that later).